### PR TITLE
fix(seo): remove trailing slash from route cannonical

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -15,10 +15,7 @@ const routeTitle = computed(() =>
 )
 const routeCanonical = computed(() => {
   if (route.meta.title?.includes('Error')) return undefined
-  else
-    return `https://dubsquared.com${route.path}${
-      route.path.length > 1 ? '/' : ''
-    }`
+  else return `https://dubsquared.com${route.path}`
 })
 </script>
 


### PR DESCRIPTION
fixes double trailing slash in google search index